### PR TITLE
Instantiate $ids to prevent a potential error with clean administrations

### DIFF
--- a/cron.php
+++ b/cron.php
@@ -119,6 +119,7 @@ function processFinancialMutations($params = array(), $debug = false) {
     'mutation_type' => 'debit',
   ]);
 
+  $ids = [];
   foreach ($versions as $version) {
     $ids[] = $version->id;
   }


### PR DESCRIPTION
If implemented on a clean moneybird administration $ids would assume a value of null. This would then trigger a TypeError when trying to call $moneybird->FinancialMutation()->getVersions();
By ensuring $ids is a valid array, this is prevented.