### PR TITLE
feat: build release artifacts per php version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,7 @@ jobs:
         with:
           artifacts: 'moneybird-${{ github.ref_name }}-php${{ matrix.php-version }}.zip'
           allowUpdates: true
+          generateReleaseNotes: true
           omitBodyDuringUpdate: true
           omitNameDuringUpdate: true
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,17 +8,32 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 1
+      matrix:
+        php-version: ['7.2', '7.3', '7.4', '8.1', '8.2', '8.3']
     steps:
-    - uses: actions/checkout@v2
-    - name: Install dependencies
-      run: composer install --prefer-dist --no-progress
-    - name: Create Release
-      id: create_release
-      uses: actions/create-release@v1
-      env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
-      with:
-        tag_name: ${{ github.ref }}
-        release_name: ${{ github.ref }}
-        draft: false
-        prerelease: false
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP ${{ matrix.php-version }}
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+
+      - name: Install dependencies
+        run: composer update --no-dev --prefer-dist --no-progress
+
+      - name: Build package
+        run: |
+          mkdir -p build/moneybird
+          rsync -a --exclude='.git' --exclude='.github' --exclude='build' ./ build/moneybird/
+          (cd build && zip -r "../moneybird-${{ github.ref_name }}-php${{ matrix.php-version }}.zip" moneybird)
+
+      - name: Create release
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: 'moneybird-${{ github.ref_name }}-php${{ matrix.php-version }}.zip'
+          allowUpdates: true
+          omitBodyDuringUpdate: true
+          omitNameDuringUpdate: true
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

Resolves #21.

Previously the release workflow created an empty GitHub release with no attached files, so users still had to run Composer to obtain the `vendor/` dependencies before they could install the module.

This reworks the release workflow so that pushing a `v*` tag builds a ready-to-use ZIP for every PHP version that WHMCS 8 and 9 support (`7.2`, `7.3`, `7.4`, `8.1`, `8.2`, `8.3` — PHP 8.0 is excluded because WHMCS does not support it). Each build installs the dependencies on that exact PHP version with `composer update --no-dev`, so the bundled `vendor/` folder is resolved for the matching PHP version. The result is packaged inside a `moneybird/` directory (so it extracts cleanly into `modules/addons/moneybird/`) and attached to the release as `moneybird-<tag>-php<version>.zip`.

Users can now download the ZIP for their PHP version and install the module without running Composer.

Also migrates off the archived `actions/create-release@v1` action to `ncipollo/release-action`, as suggested in the issue.

## Visual changes

None.

## Include translations

- [ ] Language files have been updated.

## Functional changes

- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.