### PR TITLE
feat: sync version from tag during release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,12 @@ jobs:
         with:
           php-version: ${{ matrix.php-version }}
 
+      - name: Set version
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          sed -i -E "s/(\"version\": \")[^\"]*/\1${version}/" composer.json
+          sed -i -E "s/('version'[[:space:]]*=> ')[^']*/\1${version}/" moneybird.php
+
       - name: Install dependencies
         run: composer update --no-dev --prefer-dist --no-progress
 


### PR DESCRIPTION
## Description

Until now the version number had to be kept in sync by hand in two places — `composer.json` and `moneybird.php` — before tagging a release. It was easy to forget, leaving the published module reporting an outdated version.

This adds a step to the release workflow that derives the version from the pushed tag (stripping the leading `v`, e.g. `v1.0.3` → `1.0.3`) and writes it into both files before the package is built. The bundled ZIPs and the module's reported version now always match the release tag automatically.

Builds on the per-PHP-version release work from #21.

## Visual changes

None.

## Include translations

- [ ] Language files have been updated.

## Functional changes

- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.