### PR TITLE
chore: bump actions/checkout to v5

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         php-version: ['7.2', '7.3', '7.4', '8.1', '8.2', '8.3']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup PHP ${{ matrix.php-version }}
         uses: shivammathur/setup-php@v2


### PR DESCRIPTION
## Description

The release workflow used `actions/checkout@v4`, which targets Node.js 20 and now triggers a deprecation warning on GitHub Actions runners (Node 20 is being phased out). This bumps it to `actions/checkout@v5`, which runs on Node.js 24, clearing the warning. No behavioural change.

## Visual changes

None.

## Include translations

- [ ] Language files have been updated.

## Functional changes

- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.