### PR TITLE
docs: drop unsupported note for releases page

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ you into a certain PHP version. Composer gives you this flexibility.
 
 If Composer is not for you, you can get the latest release from
 [our releases page](https://github.com/sensson/whmcs-moneybird/releases).
-This is unsupported right now.
 
 ## Installation
 


### PR DESCRIPTION
## Description

The README told users that downloading the module from the releases page was "unsupported right now". Now that the release workflow publishes ready-to-install ZIPs (with the `vendor/` folder included) for every supported PHP version, this is a fully supported install method. Removes the outdated note.

## Visual changes

None.

## Include translations

- [ ] Language files have been updated.

## Functional changes

- [x] Changes have been tested to not break existing functionality.
- [ ] Documentation is up-to-date.